### PR TITLE
[Feat] 페이지 간 라우팅 추가 및 장르선택 팝업추가

### DIFF
--- a/src/components/blueBtn/BlueBtn.jsx
+++ b/src/components/blueBtn/BlueBtn.jsx
@@ -2,9 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types'; // PropTypes 추가
 import { Container } from './BlueBtn.styles';
 
-const BlueBtn = ({ text, className, disabled, width }) => {
+const BlueBtn = ({ text, className, disabled, width, onClick }) => {
   return (
-    <Container className={className} disabled={disabled} width={width}>
+    <Container
+      className={className}
+      disabled={disabled}
+      width={width}
+      onClick={!disabled ? onClick : undefined} // 클릭 이벤트
+    >
       <p>{text}</p>
     </Container>
   );
@@ -15,11 +20,13 @@ BlueBtn.propTypes = {
   className: PropTypes.string, // className은 선택 사항
   disabled: PropTypes.bool, // disable 속성 추가
   width: PropTypes.string, // width는 선택 사항 (예: '200px')
+  onClick: PropTypes.func, // 클릭 이벤트 함수
 };
 
 BlueBtn.defaultProps = {
   disabled: false, // 기본값은 클릭 가능 상태
   width: '353px', // 기본 width
+  onClick: () => {}, // 기본값은 빈 함수
 };
 
 export default BlueBtn;

--- a/src/pages/bookmark/Bookmark.jsx
+++ b/src/pages/bookmark/Bookmark.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Container } from './Bookmark.styles';
 import StatusBar from '../../components/statusbar/StatusBar';
 import Arrow from '../../assets/arrow.svg';
@@ -21,6 +22,10 @@ const Bookmark = () => {
       isChecked: false,
     },
   ]);
+  const navigate = useNavigate(); // useNavigate 훅 사용
+  const handleBackClick = () => {
+    navigate('/home');
+  };
 
   const [popup1Visible, setPopup1Visible] = useState(false); // #popup1 상태
   const [popup2Visible, setPopup2Visible] = useState(false); // #popup2 상태
@@ -89,7 +94,12 @@ const Bookmark = () => {
       {/* 배경 오버레이 */}
       {(popup1Visible || popup2Visible) && <div className="overlay"></div>}
 
-      <img className="arrow" src={Arrow} alt="뒤로가기" />
+      <img
+        className="arrow"
+        src={Arrow}
+        alt="뒤로가기"
+        onClick={handleBackClick}
+      />
       <span className="bookmark-book">즐겨찾기 책</span>
       <div className="content-container">
         <div className="place-holder"></div>

--- a/src/pages/category/Category.jsx
+++ b/src/pages/category/Category.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Container } from './Category.styles';
 import StatusBar from '../../components/statusbar/StatusBar';
 import BlueBtn from '../../components/blueBtn/BlueBtn';
 import Title from '../../assets/title.svg';
 import Item from './Item';
+import X from './x.svg';
 
 const genres = [
   '문학',
@@ -21,6 +23,8 @@ const genres = [
 ];
 
 const Category = () => {
+  const navigate = useNavigate(); // useNavigate 훅 사용
+  const [popupVisible, setPopupVisible] = useState(false); // #popup1 상태
   // 선택 상태를 배열로 관리
   const [selectedStates, setSelectedStates] = useState(
     Array(genres.length).fill(false)
@@ -28,22 +32,51 @@ const Category = () => {
 
   // 선택된 항목 개수 계산
   const selectedCount = selectedStates.filter((state) => state).length;
+  //const canSelectMore = selectedCount < 3;
+  const handleBtnClick = () => {
+    navigate('/onboarding');
+  };
 
   // 항목 클릭 시 상태 업데이트
   const handleSelect = (index) => {
     setSelectedStates((prevStates) => {
       const newStates = [...prevStates];
-      newStates[index] = !newStates[index]; // 클릭된 항목 상태 토글
-      return newStates;
+
+      // 선택 상태를 변경
+      newStates[index] = !newStates[index];
+      const newSelectedCount = newStates.filter((state) => state).length;
+
+      // 선택 후 초과 여부 확인
+      if (newSelectedCount > 3) {
+        handleShowPopup(); // 초과 선택 시 팝업 표시
+        return prevStates; // 상태 업데이트 방지
+      }
+      console.log(`몇개선택했는지 > `, newSelectedCount);
+      return newStates; // 정상적으로 상태 업데이트
     });
   };
 
-  // 선택 가능 여부 판단
-  const canSelectMore = selectedCount < 3;
+  const handleShowPopup = () => {
+    console.log('최대 3개까지만 선택합시다!'); // 호출 여부 확인
+    setPopupVisible(true);
+  };
+
+  const closePopup = () => {
+    setPopupVisible(false);
+  };
 
   return (
     <Container>
       <StatusBar />
+      {popupVisible && <div className="overlay"></div>}
+
+      {popupVisible && ( // popup1Visible 상태에 따라 조건부 렌더링 추가
+        <div id="pop-up">
+          <span className="pop-up-text">최대 3개 선택 가능합니다</span>
+          <img className="x-icon" src={X} alt="x표시" onClick={closePopup} />
+        </div>
+      )}
+
       <img className="title" src={Title} alt="제목" />
       <p className="interest">
         관심 장르 선택&nbsp;
@@ -56,15 +89,15 @@ const Category = () => {
             key={index}
             text={genre}
             isSelected={selectedStates[index]} // 선택 상태 전달
-            canSelectMore={canSelectMore} // 선택 가능 여부 전달
             onToggleSelect={() => handleSelect(index)} // 상태 업데이트 함수 전달
           />
         ))}
       </div>
       <BlueBtn
         text="선택완료"
-        disabled={selectedCount !== 3} // 3개 선택 시만 활성화
+        //disabled={selectedCount !== 3} // 3개 선택 시만 활성화
         className="start-btn"
+        onClick={handleBtnClick}
       />
     </Container>
   );

--- a/src/pages/category/Category.styles.jsx
+++ b/src/pages/category/Category.styles.jsx
@@ -67,4 +67,44 @@ export const Container = styled.div`
     line-height: var(--Label-Medium-Line-Height, 16px); /* 100% */
     letter-spacing: var(--Label-Medium-Tracking, 0.5px);
   }
+
+  .overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 393px;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.42);
+    z-index: 100; /* 팝업 아래 배경보다 높은 z-index */
+  }
+
+  #pop-up {
+    position: fixed;
+    background-color: #fff;
+    border-radius: 14px;
+    box-shadow: 0px 2.73px 2.73px 0px rgba(0, 0, 0, 0.25);
+    left: 63px;
+    top: 395px;
+    width: 268px;
+    height: 62px;
+    z-index: 2000;
+  }
+
+  .pop-up-text {
+    position: absolute;
+    top: 22px;
+    left: 71px;
+    color: #000;
+    font-family: Pretendard;
+    font-size: 13px;
+    font-style: normal;
+    font-weight: 600;
+  }
+
+  .x-icon {
+    position: absolute;
+    top: 14px;
+    right: 15px;
+    cursor: pointer;
+  }
 `;

--- a/src/pages/category/Item.jsx
+++ b/src/pages/category/Item.jsx
@@ -2,10 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CategoryItem } from './Item.styles';
 
-const Item = ({ text, isSelected, canSelectMore, onToggleSelect }) => {
+const Item = ({ text, isSelected, onToggleSelect }) => {
   const handleClick = () => {
-    // 선택 가능 여부 판단
-    if (!isSelected && !canSelectMore) return;
     onToggleSelect(); // 부모 컴포넌트에서 상태 업데이트
   };
 
@@ -19,7 +17,6 @@ const Item = ({ text, isSelected, canSelectMore, onToggleSelect }) => {
 Item.propTypes = {
   text: PropTypes.string.isRequired,
   isSelected: PropTypes.bool.isRequired, // 선택 상태
-  canSelectMore: PropTypes.bool.isRequired, // 선택 가능 여부
   onToggleSelect: PropTypes.func.isRequired, // 상태 업데이트 함수
 };
 

--- a/src/pages/category/x.svg
+++ b/src/pages/category/x.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
+<path d="M1 13L13 1" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13 13L1 1" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Container, Wrapper } from './Home.styles';
 import StatusBar from '../../components/statusbar/StatusBar';
 import Title from '../../assets/title.svg';
@@ -17,12 +18,27 @@ import DummyBook2 from '../../assets/dummyBook2.svg';
 import InfoPopup from '../../components/infoPopup/InfoPopup';
 //import DummyBook3 from '../../assets/dummyBook3.svg';
 const Home = () => {
+  const navigate = useNavigate(); // useNavigate 훅 사용
   //const [bookCount, setBookCount] = useState(0); // 백엔드에서 가져올 값
   const [bookCount] = useState(4); // 진행중인 기록 - 백엔드에서 가져올 값
   const [readingCount] = useState(31); // 읽기 횟수 - 백엔드에서 가져올 값
   const [showInfoPopup, setShowInfoPopup] = useState(false); // InfoPopup 상태
   const [selectedBook, setSelectedBook] = useState(null); // 현재 선택된 책 정보
   const [popup1Visible, setPopup1Visible] = useState(false); // #popup1 상태
+
+  const handleRecordClick = () => {
+    navigate('/record');
+  };
+
+  const handleBookmarkClick = () => {
+    navigate('/bookmark');
+  };
+
+  //책 찾기 클릭
+  const handleSearchClick = () => {
+    navigate('/search'); // '/search'로 네비게이션
+  };
+
   // InfoPopup 관련
   const handleDotsClick = (book) => {
     setSelectedBook(book); // 선택된 책 업데이트
@@ -79,7 +95,12 @@ const Home = () => {
           </div>
         )}
         <img className="title" src={Title} alt="제목" />
-        <img className="star" src={Star} alt="별 아이콘" />
+        <img
+          className="star"
+          src={Star}
+          alt="별 아이콘"
+          onClick={handleBookmarkClick}
+        />
         <img className="bell" src={Bell} alt="벨 아이콘" />
         <span className="user-name">
           닉네임 <span>님</span>
@@ -106,12 +127,22 @@ const Home = () => {
               <p className="line2">독서 기록과 이야기가 담길</p>
               <p className="line3">특별한 공간입니다.</p>
               <p className="line4">지금 책을 찾으러 가보세요!</p>
-              <BlueBtn className={'btn'} text="책 찾기" width={'351px'} />
+              <BlueBtn
+                className={'btn'}
+                text="책 찾기"
+                width={'351px'}
+                onClick={handleSearchClick}
+              />
             </div>
             <div
               className={`place-holder-list ${bookCount === 0 ? 'hidden' : ''}`}
             >
-              <img className="arrow" src={Arrow} alt="화살표" />
+              <img
+                className="arrow"
+                src={Arrow}
+                alt="화살표"
+                onClick={handleRecordClick}
+              />
               <div className="book-scroll-container">
                 <BookFrame
                   imageSrc={DummyBook1}

--- a/src/pages/onboarding/Onboarding.jsx
+++ b/src/pages/onboarding/Onboarding.jsx
@@ -1,19 +1,29 @@
-import React from 'react'
-import { Container } from './Onboarding.styles'
-import StatusBar from '../../components/statusbar/StatusBar'
-import BlueBtn from '../../components/blueBtn/BlueBtn'
-import Circle from "../../assets/circle.svg"
-import Title from "../../assets/title.svg"
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Container } from './Onboarding.styles';
+import StatusBar from '../../components/statusbar/StatusBar';
+import BlueBtn from '../../components/blueBtn/BlueBtn';
+import Circle from '../../assets/circle.svg';
+import Title from '../../assets/title.svg';
 const Onboarding = () => {
+  const navigate = useNavigate(); // useNavigate 훅 사용
+
+  const handleBtnClick = () => {
+    navigate('/home');
+  };
   return (
     <Container>
-        <StatusBar />
-        <img className='logo' src={Circle} alt="로고" />
-        <img className='title' src={Title} alt="제목" />
-        <p className='user-hello'>닉네임 님, 안녕하세요</p>
-        <BlueBtn text={'시작하기'} className={"blue-btn"} />
+      <StatusBar />
+      <img className="logo" src={Circle} alt="로고" />
+      <img className="title" src={Title} alt="제목" />
+      <p className="user-hello">닉네임 님, 안녕하세요</p>
+      <BlueBtn
+        text={'시작하기'}
+        className={'blue-btn'}
+        onClick={handleBtnClick}
+      />
     </Container>
-  )
-}
+  );
+};
 
-export default Onboarding
+export default Onboarding;

--- a/src/pages/profile/Profile.jsx
+++ b/src/pages/profile/Profile.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Container } from './Profile.styles';
 import StatusBar from '../../components/statusbar/StatusBar';
 import ValidTestInput from '../signup/ValidTestInput';
@@ -7,6 +8,12 @@ import ProfileImg from './profileImg.svg';
 import Plus from './plus.svg';
 import BlueBtn from '../../components/blueBtn/BlueBtn';
 const Profile = () => {
+  const navigate = useNavigate(); // useNavigate 훅 사용
+
+  const handlerBackBtnClick = () => {
+    navigate('/signup');
+  };
+
   // 닉네임 중복 여부를 확인하는 함수
   const validateNickname = (value) => {
     const existingNicknames = ['testUser', 'admin', 'user123']; // 서버에서 받아온 데이터라고 가정
@@ -38,7 +45,7 @@ const Profile = () => {
         중복확인
       </span>
       <div className="btn-container">
-        <div className="back-btn">
+        <div className="back-btn" onClick={handlerBackBtnClick}>
           <p>이전</p>
         </div>
         <BlueBtn className={'next'} text="다음" width={'167px'} />

--- a/src/pages/record/Record.jsx
+++ b/src/pages/record/Record.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Container } from './Record.styles';
 import StatusBar from '../../components/statusbar/StatusBar';
 import BackBtn from '../../assets/arrow.svg';
@@ -13,11 +14,17 @@ import Dummy4 from './dummy4.svg';
 import InfoPopup from '../../components/infoPopup/InfoPopup';
 
 const Record = () => {
+  const navigate = useNavigate(); // useNavigate 훅 사용
   const [showSortPopup, setShowSortPopup] = useState(false); // Sort 팝업 상태
   const [showInfoPopup, setShowInfoPopup] = useState(false); // InfoPopup 상태
   const [selectedOrder, setSelectedOrder] = useState('latest-order'); // 기본 선택: 최신순
   const [selectedBook, setSelectedBook] = useState(null); // 현재 선택된 책 정보
   const [popup1Visible, setPopup1Visible] = useState(false); // #popup1 상태
+
+  const handleBackClick = () => {
+    navigate('/home');
+  };
+
   // Sort 팝업 관련
   const handleSortClick = () => {
     setShowSortPopup(true); // Sort 팝업 표시
@@ -94,7 +101,12 @@ const Record = () => {
       )}
 
       <div className="header">
-        <img className="back-btn" src={BackBtn} alt="뒤로가기" />
+        <img
+          className="back-btn"
+          src={BackBtn}
+          alt="뒤로가기"
+          onClick={handleBackClick}
+        />
         <p className="title-message">
           <span className="nickname">닉네임</span>님의 진행중 기록
         </p>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

- 회원가입시 프로필 사진 생성 화면 -->>뒤로가기>> 회원가입 화면
- 선호장르 선택 -->>시작하기>> 온보딩 화면
- 온보딩화면 -->>시작하기>> 홈화면
- 홈화면 <-> 기록더보기 or 즐겨찾기 화면
위에 대한 라우팅 처리 완료

- 라우팅 처리 하다가 회원가입 장르선택 화면에서 팝업처리가 안된 것을 확인하여 이부분 구현 하였습니다.
 
## 📸 스크린샷

![image](https://github.com/user-attachments/assets/d71560ec-a4cb-4aef-975b-1352102be6dc)

## 💬 리뷰 요구사항

> merge 할때 이전에 건들인 부분에 대해서 충돌이 날 것 같습니다. 발생한 conflict들은 제 로컬 코드 기준으로 춰두겠습니다! 

