### PR TITLE
[Feat] 같이읽기, 혼자읽기 방생성 API 구현완료

### DIFF
--- a/src/apis/getBookInfo.js
+++ b/src/apis/getBookInfo.js
@@ -3,7 +3,7 @@ import instance from './instance'; // Axios 인스턴스 가져오기
 export const getBookInfo = async () => {
   const accessToken =
     'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjEwLCJpYXQiOjE3Mzg1NjIwMDcsImV4cCI6MTczODU2NTYwN30.jwDe5klrfF_30C_3uBz3X57rLv59TdbgM1KcS-7JSwo';
-  const isbn = '9791141977726'; // ✅ 임시 하드코딩된 ISBN 값
+  const isbn = '9791194374084'; // ✅ 임시 하드코딩된 ISBN 값
 
   try {
     const response = await instance.get(`/books/info/${isbn}`, {

--- a/src/components/MakeReadwithTogether/MakeReadwithTogether.jsx
+++ b/src/components/MakeReadwithTogether/MakeReadwithTogether.jsx
@@ -1,11 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, forwardRef, useImperativeHandle } from 'react';
 import { Wrapper, Button } from './MakeReadwithTogether.styles';
 import { createRoom } from '../../apis/room'; // 방 생성 API 호출
-import { useParams } from 'react-router-dom'; // ✅ URL에서 파라미터 가져오기
+//import { useParams } from 'react-router-dom'; // ✅ URL에서 파라미터 가져오기
 
-export default function MakeReadwithTogether() {
-  const { roomId } = useParams();
-  const [isbn, setIsbn] = useState('');
+const MakeReadwithTogether = forwardRef((props, ref) => {
+  const isbn = '9791141977726'; // ✅ 하드코딩된 ISBN 값
+
+  //  const { roomId } = useParams();
+  //  const [isbn, setIsbn] = useState('');
 
   const today = new Date();
   const formattedDate = `${today.getFullYear()}.${String(today.getMonth() + 1).padStart(2, '0')}.${String(today.getDate()).padStart(2, '0')}`;
@@ -22,7 +24,7 @@ export default function MakeReadwithTogether() {
   const [passwordError, setPasswordError] = useState('');
   const [endDate, setEndDate] = useState('');
 
-  // ✅ 동적으로 roomId 값을 받아서 방 정보 가져오기
+  /*   // ✅ 동적으로 roomId 값을 받아서 방 정보 가져오기
   useEffect(() => {
     const fetchRoomInfo = async () => {
       if (!roomId) return; // roomId가 없으면 실행하지 않음
@@ -36,20 +38,7 @@ export default function MakeReadwithTogether() {
     };
 
     fetchRoomInfo();
-  }, [roomId]); // roomId 변경 시마다 실행
-
-  /*   // ISBN 가져오기 (GET /rooms/{roomId})
-  useEffect(() => {
-    const fetchIsbn = async () => {
-      try {
-        const roomData = await getRoomInfo(1); // 실제 roomId 값 적용 필요
-        setIsbn(roomData.isbn);
-      } catch (error) {
-        console.error('❌ ISBN 가져오기 실패:', error);
-      }
-    };
-    fetchIsbn();
-  }, []); */
+  }, [roomId]); // roomId 변경 시마다 실행 */
 
   // 방 이름 입력 핸들러
   const handleRoomNameChange = (e) => {
@@ -108,22 +97,20 @@ export default function MakeReadwithTogether() {
     setEndDate(value);
   };
 
-  // 방 생성 API 호출
-  const handleCreateGroupRoom = async () => {
-    if (!roomName.trim()) return setRoomNameError('* 방 이름을 입력해주세요');
-    if (!participants || participants < 2 || participants > 50)
-      return setParticipantsError('* 최소 2명 ~ 최대 50명입니다');
-    if (selected === '비공개' && password.length < 4)
-      return setPasswordError('* 숫자 4자리를 입력해주세요');
+  // ✅ 부모 컴포넌트에서 호출할 수 있도록 `createGroupRoom` 함수 노출
+  useImperativeHandle(ref, () => ({
+    createGroupRoom,
+  }));
 
+  // 방 생성 API 호출
+  const createGroupRoom = async () => {
     const roomData = {
-      roomName,
+      roomName: roomName || null, // 방 이름이 없으면 null
       progressStartDate: formattedDate,
-      progressEndDate: endDate,
-      recruitCount: parseInt(participants, 10),
-      password: selected === '비공개' ? password : null,
-      isbn,
-      public: selected === '공개',
+      progressEndDate: endDate || null, // 종료 날짜 없으면 null
+      recruitCount: participants ? parseInt(participants, 10) : null,
+      password: selected === '비공개' && password ? password : null,
+      isbn, // ✅ 하드코딩된 ISBN 포함
       isPublic: selected === '공개',
     };
 
@@ -219,13 +206,12 @@ export default function MakeReadwithTogether() {
             {passwordError && <div className="error">{passwordError}</div>}
           </div>
         )}
-
-        <button
-          id="group-create-room-btn"
-          style={{ display: 'none' }}
-          onClick={handleCreateGroupRoom}
-        />
       </Wrapper>
     </>
   );
-}
+});
+
+// ✅ displayName 추가하여 경고 해결
+MakeReadwithTogether.displayName = 'MakeReadwithTogether';
+
+export default MakeReadwithTogether;

--- a/src/components/MakeReadwithTogether/MakeReadwithTogether.jsx
+++ b/src/components/MakeReadwithTogether/MakeReadwithTogether.jsx
@@ -118,6 +118,7 @@ const MakeReadwithTogether = forwardRef((props, ref) => {
       const roomId = await createRoom(roomData);
       console.log(`🎉 같이 읽는 방 생성 성공! roomId: ${roomId}`);
       alert('같이 읽는 방이 성공적으로 생성되었습니다!');
+      return roomId;
     } catch (error) {
       console.error(`❌ 방 생성 실패:`, error.message);
       alert(error.message);

--- a/src/pages/MakeReadwith/MakeReadwith.jsx
+++ b/src/pages/MakeReadwith/MakeReadwith.jsx
@@ -4,8 +4,10 @@ import RWFooter from '../../components/RWFooter/RWFooter';
 import { Wrapper, Button, ButtonContainer } from './MakeReadwith.styles';
 import MakeReadwithTogether from '../../components/MakeReadwithTogether/MakeReadwithTogether';
 import { createRoom } from '../../apis/room'; // 방 생성 API 호출
+import { useNavigate } from 'react-router-dom';
 
 export default function MakeReadwith() {
+  const navigate = useNavigate(); // ✅ useNavigate 사용
   const [selected, setSelected] = useState('혼자');
   const isbn = '9791141977726'; // ✅ 하드코딩된 ISBN
   const makeReadwithTogetherRef = useRef(null); // ✅ `MakeReadwithTogether` 참조
@@ -15,29 +17,32 @@ export default function MakeReadwith() {
   };
 
   const handleCreateRoom = async () => {
-    if (selected === '혼자') {
-      // ✅ 혼자 읽기 방 생성 요청
-      const roomData = {
-        isPublic: false, // ✅ 항상 false
-        roomName: null, // ❌ 방 이름 없음
-        progressStartDate: null, // ❌ 시작 날짜 없음
-        progressEndDate: null, // ❌ 종료 날짜 없음
-        recruitCount: 1, // ✅ 혼자 읽기 방은 1명
-        password: null, // ❌ 비밀번호 없음
-        isbn, // ✅ 하드코딩된 ISBN
-      };
+    try {
+      let roomId = null;
 
-      try {
-        const roomId = await createRoom(roomData);
-        console.log(`🎉 혼자 기록하는 방 생성 성공! roomId: ${roomId}`);
-        alert('혼자 기록하는 방이 성공적으로 생성되었습니다!');
-      } catch (error) {
-        console.error(`❌ 방 생성 실패:`, error.message);
-        alert(error.message);
+      if (selected === '혼자') {
+        const roomData = {
+          isPublic: false,
+          roomName: null,
+          progressStartDate: null,
+          progressEndDate: null,
+          recruitCount: 1,
+          password: null,
+          isbn,
+        };
+
+        roomId = await createRoom(roomData);
+        console.log(`🎉 혼자 읽기 방 생성 성공! roomId: ${roomId}`);
+      } else if (selected === '같이' && makeReadwithTogetherRef.current) {
+        roomId = await makeReadwithTogetherRef.current.createGroupRoom();
       }
-    } else if (selected === '같이' && makeReadwithTogetherRef.current) {
-      // ✅ 같이 읽기 데이터를 `MakeReadwithTogether`에서 가져와 방 생성 요청
-      makeReadwithTogetherRef.current.createGroupRoom();
+
+      if (roomId) {
+        navigate('/readWith'); // ✅ 방 생성 후 '/readWith' 페이지로 이동, 추후 수정
+      }
+    } catch (error) {
+      console.error(`❌ 방 생성 실패:`, error.message);
+      alert(error.message);
     }
   };
 

--- a/src/pages/MakeReadwith/MakeReadwith.jsx
+++ b/src/pages/MakeReadwith/MakeReadwith.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import RWHeader from '../../components/RWHeader/RWHeader';
 import RWFooter from '../../components/RWFooter/RWFooter';
 import { Wrapper, Button, ButtonContainer } from './MakeReadwith.styles';
@@ -7,15 +7,24 @@ import { createRoom } from '../../apis/room'; // 방 생성 API 호출
 
 export default function MakeReadwith() {
   const [selected, setSelected] = useState('혼자');
+  const isbn = '9791141977726'; // ✅ 하드코딩된 ISBN
+  const makeReadwithTogetherRef = useRef(null); // ✅ `MakeReadwithTogether` 참조
+
   const handleButtonClick = (option) => {
     setSelected(option); // 클릭한 버튼의 상태를 선택
   };
 
   const handleCreateRoom = async () => {
     if (selected === '혼자') {
-      // 혼자 방 생성 요청
+      // ✅ 혼자 읽기 방 생성 요청
       const roomData = {
-        recruitCount: 1, // 혼자일 경우 필수 데이터
+        isPublic: false, // ✅ 항상 false
+        roomName: null, // ❌ 방 이름 없음
+        progressStartDate: null, // ❌ 시작 날짜 없음
+        progressEndDate: null, // ❌ 종료 날짜 없음
+        recruitCount: 1, // ✅ 혼자 읽기 방은 1명
+        password: null, // ❌ 비밀번호 없음
+        isbn, // ✅ 하드코딩된 ISBN
       };
 
       try {
@@ -26,9 +35,9 @@ export default function MakeReadwith() {
         console.error(`❌ 방 생성 실패:`, error.message);
         alert(error.message);
       }
-    } else if (selected === '같이') {
-      // 같이 선택 시, MakeReadwithTogether 내부 버튼 클릭하도록 트리거
-      document.getElementById('group-create-room-btn')?.click();
+    } else if (selected === '같이' && makeReadwithTogetherRef.current) {
+      // ✅ 같이 읽기 데이터를 `MakeReadwithTogether`에서 가져와 방 생성 요청
+      makeReadwithTogetherRef.current.createGroupRoom();
     }
   };
 
@@ -51,7 +60,9 @@ export default function MakeReadwith() {
             <div>여러명이서 기록할래요</div>
           </Button>
         </ButtonContainer>
-        {selected === '같이' && <MakeReadwithTogether />}
+        {selected === '같이' && (
+          <MakeReadwithTogether ref={makeReadwithTogetherRef} />
+        )}
         <RWFooter onCreateRoom={handleCreateRoom} />
       </Wrapper>
     </>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 방 생성하기 API 연동 및 코드 구현
2. 방 생성 후 해당 방으로 이동 (추가로 생성한 방 불러올때, 혼자읽기 방은 GET안되고 같이읽기 방은 방정보 GET 되어지는것까지 확인했읍니다~~~)

## 📸 스크린샷

> 설명을 위해 스크린샷이 필요하다면 첨부해주세요

![image](https://github.com/user-attachments/assets/7ace01af-0a63-4bf9-8d78-e841944385a4)
<img width="1421" alt="image" src="https://github.com/user-attachments/assets/511fecca-0b96-43ec-9e9f-4cb493dc1018" />
<img width="1421" alt="image" src="https://github.com/user-attachments/assets/ba663839-5c30-41e3-b042-6e4e14f71cac" />



## 💬 리뷰 요구사항

useRef...를 써서 만들긴했는데 아무래도 RWFooter를 없애고 useRef없애고 구현하는 방향으로 코드 다시 만들어야할거같아요


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
