### PR TITLE
[Feat] api 구현완료- 이메일 인증요청, 인증확인, 닉네임 중복확인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1565,7 +1565,6 @@
       "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
       "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/src/apis/authApi.js
+++ b/src/apis/authApi.js
@@ -50,3 +50,41 @@ export const login = async (email, password) => {
     throw error;
   }
 };
+
+// ✅ AccessToken 재발급 API 요청 함수
+export const reissueAccessToken = async () => {
+  try {
+    const refreshToken = localStorage.getItem('refreshToken'); // 로컬 스토리지에서 refreshToken 가져오기
+    if (!refreshToken) {
+      console.warn('[WARNING] RefreshToken이 없습니다. 다시 로그인하세요.');
+      throw new Error('RefreshToken이 존재하지 않습니다.');
+    }
+
+    console.log('[DEBUG] AccessToken 재발급 요청 시작');
+
+    const response = await apiClient.post('/auth/reissue', { refreshToken });
+
+    console.log('[DEBUG] AccessToken 재발급 API 응답:', response);
+
+    console.log(
+      `여기 진짜 주목 response.data.accessToken = ${response.data.data.accessToken}`
+    );
+    console.log(`여기주목 response.data.status = ${response.data.status}`);
+    console.log(`여기주목 response.data.code = ${response.data.code}`);
+
+    if (response.data.code === 200) {
+      const newAccessToken = response.data.data.accessToken; // 백엔드 명세서에 맞게 필드명 확인
+      console.log('[DEBUG] 새로운 AccessToken:', newAccessToken);
+
+      localStorage.setItem('accessToken', newAccessToken); // 새 AccessToken 저장
+
+      return newAccessToken; // 새 AccessToken 반환
+    } else {
+      console.warn('[WARNING] AccessToken 재발급 실패:', response.data.message);
+      throw new Error(response.data.message);
+    }
+  } catch (error) {
+    console.error('[ERROR] AccessToken 재발급 실패:', error);
+    throw error;
+  }
+};

--- a/src/apis/authApi.js
+++ b/src/apis/authApi.js
@@ -1,0 +1,52 @@
+import apiClient from '../apis/instance/apiClient'; // axios 인스턴스 가져오기
+//로그인 API 요청 처리
+export const login = async (email, password) => {
+  try {
+    console.log('[DEBUG] 로그인 요청 시작:', { email, password });
+
+    const response = await apiClient.post(
+      '/auth/login',
+      { email, password },
+      {
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    console.log('[DEBUG] 로그인 API 응답:', response); // 응답 전체 출력
+
+    if (!response || !response.data) {
+      throw new Error('서버 응답이 올바르지 않습니다.');
+    }
+
+    const responseData = response.data; // response.data 객체 추출
+    console.log('[DEBUG] 반환할 responseData:', responseData);
+
+    const { accessToken, refreshToken, userId } = responseData.data;
+
+    if (!accessToken || !refreshToken || !userId) {
+      throw new Error('서버 응답에서 필요한 데이터가 없습니다.');
+    }
+
+    console.log('[DEBUG] responseData.code:', responseData.code);
+
+    if (responseData.code === 200) {
+      console.log('[DEBUG] 응답 데이터 구조:', responseData.data);
+
+      // ✅ accessToken을 API 요청 헤더에 추가 (자동 적용)
+      //setAccessToken(accessToken);
+
+      //accessToken을 localStorage 또는 sessionStorage에 저장
+      //localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
+      localStorage.setItem('userId', userId);
+
+      console.log('[DEBUG] refreshToken 저장 완료:', refreshToken);
+
+      return responseData; // 성공 응답 반환
+    }
+  } catch (error) {
+    console.error('[ERROR] 로그인 실패:', error);
+    console.error('[ERROR] 응답 객체:', error.response);
+    throw error;
+  }
+};

--- a/src/apis/instance/apiClient.js
+++ b/src/apis/instance/apiClient.js
@@ -1,0 +1,41 @@
+import instance from './index'; // 기본 axios 인스턴스 가져오기
+//accessToken 포함 및 인터셉터 설정 파일
+
+const apiClient = instance; // 기존 instance.js를 사용
+
+//const accessToken =
+//  'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjQsImlhdCI6MTczODU1MDgwOCwiZXhwIjoxNzM4NTU0NDA4fQ.1zPjVYpRywLtNUSjm06p-wDvwkovOC1VEbu_qsJ96kE';
+
+export const setAccessToken = (token) => {
+  localStorage.setItem('accessToken', token); // 토큰을 localStorage에도 저장
+};
+
+// 요청 인터셉터 - accessToken 자동 추가
+apiClient.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('accessToken'); // 최신 토큰 가져오기
+    console.log('[DEBUG] 요청 전송 전 - Authorization 헤더:', token);
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터 - 인증 실패 시 로그아웃 처리
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      console.warn('토큰 만료 또는 인증 오류 발생! 로그아웃 처리.');
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      localStorage.removeItem('userId');
+      window.location.href = '/login'; // 로그인 페이지로 이동
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;

--- a/src/apis/instance/apiClient.js
+++ b/src/apis/instance/apiClient.js
@@ -1,4 +1,5 @@
 import instance from './index'; // 기본 axios 인스턴스 가져오기
+import { reissueAccessToken } from '../authApi'; // AccessToken 재발급 함수 가져오기
 //accessToken 포함 및 인터셉터 설정 파일
 
 const apiClient = instance; // 기존 instance.js를 사용
@@ -23,17 +24,63 @@ apiClient.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
-// 응답 인터셉터 - 인증 실패 시 로그아웃 처리
+// 응답 인터셉터 - 7006 인증 실패 시 로그아웃 처리
 apiClient.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response && error.response.status === 401) {
-      console.warn('토큰 만료 또는 인증 오류 발생! 로그아웃 처리.');
+  (response) => {
+    console.log('[DEBUG] 응답 인터셉터 실행 - 정상 응답:', response);
+    return response;
+  },
+  async (error) => {
+    console.error('[DEBUG] API 응답 에러 발생:', error); // ✅ 여기 찍혀야 함
+
+    if (!error.response) {
+      console.error('[ERROR] 응답이 없습니다. 네트워크 문제 가능.');
+      return Promise.reject(error);
+    }
+
+    console.log('[DEBUG] 에러 응답 전체:', error.response?.data); // ✅ 여기 찍혀야 함
+
+    const errorCode = error.response?.data?.code; // 백엔드 응답 코드 확인
+    console.log(`[DEBUG] errorCode : ${errorCode}`); // 여기 찍혀야 함
+
+    // ✅ 최대 재시도 횟수 설정 (ex: 2번)
+    error.config._retryCount = error.config._retryCount || 0;
+
+    if (errorCode === 7006 && error.config._retryCount < 1) {
+      console.warn('[WARNING] AccessToken 만료! 재발급 시도');
+      console.log('[DEBUG] AccessToken 재발급 요청 시작'); // 여기 찍혀야 함
+
+      error.config._retryCount += 1; // ✅ 재시도 횟수 증가
+
+      try {
+        const newAccessToken = await reissueAccessToken(); // 새 AccessTo ken 요청
+        console.log('[DEBUG] 새 AccessToken:', newAccessToken);
+
+        // 새 AccessToken을 기존 요청에 추가하여 재시도
+        error.config.headers.Authorization = `Bearer ${newAccessToken}`;
+        return apiClient.request(error.config); // 기존 요청 다시 보내기
+      } catch (refreshError) {
+        console.error(
+          '[ERROR] AccessToken 재발급 실패 - 재로그인 필요:',
+          refreshError
+        );
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        localStorage.removeItem('userId');
+        window.location.href = '/login'; // 로그인 페이지로 이동
+        return Promise.reject(refreshError);
+      }
+    }
+
+    if (errorCode === 7005) {
+      console.warn('[WARNING] 유효하지 않은 토큰! 로그아웃 처리.');
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
       localStorage.removeItem('userId');
       window.location.href = '/login'; // 로그인 페이지로 이동
+      return Promise.reject(error);
     }
+
     return Promise.reject(error);
   }
 );

--- a/src/apis/verification.js
+++ b/src/apis/verification.js
@@ -74,3 +74,36 @@ export const verifyEmailCode = async (email, code) => {
     }
   }
 };
+
+// 닉네임 중복 확인 API
+export const checkNicknameAvailability = async (nickname) => {
+  try {
+    if (!nickname) {
+      throw new Error('닉네임을 입력해주세요.');
+    }
+
+    console.log('[DEBUG] 닉네임 중복 확인 요청 시작:', nickname);
+
+    const response = await apiClient.post('/users/nickname', {
+      nickName: nickname,
+    });
+
+    console.log('[DEBUG] 닉네임 중복 확인 API 응답:', response);
+
+    if (response.data.code === 200) {
+      return response.data.data.verified; // 닉네임 사용 가능 여부 반환
+    } else {
+      throw new Error('서버 응답이 올바르지 않습니다.');
+    }
+  } catch (error) {
+    console.error('[ERROR] 닉네임 중복 확인 실패:', error);
+
+    if (error.response) {
+      throw new Error(
+        error.response.data?.message || '닉네임 중복 확인 중 오류 발생'
+      );
+    } else {
+      throw new Error('네트워크 오류 또는 서버 응답 없음');
+    }
+  }
+};

--- a/src/apis/verification.js
+++ b/src/apis/verification.js
@@ -1,0 +1,76 @@
+import apiClient from '../apis/instance/apiClient'; // axios 인스턴스 가져오기
+
+// 이메일 인증 요청 API
+export const requestEmailVerification = async (email) => {
+  try {
+    if (!email) {
+      throw new Error('이메일은 필수 입력 항목입니다.');
+    }
+
+    console.log('[DEBUG] 이메일 인증 요청 시작:', email);
+
+    const response = await apiClient.post(
+      '/users/emails/vertifications-requests',
+      { email }
+    );
+
+    console.log('[DEBUG] 이메일 인증 API 응답:', response);
+
+    if (response.data.code === 200) {
+      console.log('[DEBUG] 인증 코드 전송 완료');
+      return response.data; // 성공 응답 반환
+    }
+  } catch (error) {
+    console.error('[ERROR] 이메일 인증 요청 실패:', error);
+
+    if (error.response) {
+      console.error(
+        '[ERROR] 서버 응답 메시지:',
+        error.response.data?.message || '알 수 없는 오류'
+      );
+      throw new Error(
+        error.response.data?.message ||
+          '이메일 인증 요청 중 오류가 발생했습니다.'
+      );
+    } else {
+      throw new Error('네트워크 오류 또는 서버 응답 없음');
+    }
+  }
+};
+
+// 이메일 인증번호 검증 API 추가
+export const verifyEmailCode = async (email, code) => {
+  try {
+    if (!email) {
+      throw new Error('이메일은 필수 입력 항목입니다.');
+    }
+    if (!code) {
+      throw new Error('인증할 코드를 입력해주세요.');
+    }
+
+    console.log('[DEBUG] 이메일 인증번호 검증 요청:', { email, code });
+
+    const response = await apiClient.post('/users/emails/vertifications', {
+      email,
+      code,
+    });
+
+    console.log('[DEBUG] 이메일 인증번호 검증 API 응답:', response);
+
+    if (response.data.code === 200 && response.data.data.verified) {
+      console.log('[DEBUG] 인증 성공!');
+      return true; // 인증 성공
+    } else {
+      throw new Error('인증에 실패하였습니다.');
+    }
+  } catch (error) {
+    console.error('[ERROR] 이메일 인증번호 검증 실패:', error);
+    if (error.response) {
+      throw new Error(
+        error.response.data?.message || '인증번호 확인 중 오류가 발생했습니다.'
+      );
+    } else {
+      throw new Error('네트워크 오류 또는 서버 응답 없음');
+    }
+  }
+};

--- a/src/components/userInputField/UserInputField.jsx
+++ b/src/components/userInputField/UserInputField.jsx
@@ -2,19 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { InputWrapper, StyledInput, LabelText } from './UserInputField.styles';
 
-const UserInputField = ({ placeholder, labelText }) => {
+const UserInputField = ({ placeholder, labelText, value, onChange }) => {
   return (
     <InputWrapper>
-      {/* labelText는 값이 있을 때만 표시 */}
-      <LabelText>{labelText}</LabelText>
-      <StyledInput placeholder={placeholder} />
+      {/* labelText가 있을 때만 표시 */}
+      {labelText && <LabelText>{labelText}</LabelText>}
+      <StyledInput
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+      />
     </InputWrapper>
   );
 };
 
 UserInputField.propTypes = {
-  placeholder: PropTypes.string.isRequired, //placeholder는 필수
-  labelText: PropTypes.string, // labelText는 선택
+  placeholder: PropTypes.string.isRequired,
+  labelText: PropTypes.string,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default UserInputField;

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Container, Wrapper } from './Home.styles';
 import StatusBar from '../../components/statusbar/StatusBar';
@@ -25,6 +25,21 @@ const Home = () => {
   const [showInfoPopup, setShowInfoPopup] = useState(false); // InfoPopup 상태
   const [selectedBook, setSelectedBook] = useState(null); // 현재 선택된 책 정보
   const [popup1Visible, setPopup1Visible] = useState(false); // #popup1 상태
+
+  useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken');
+    const refreshToken = localStorage.getItem('refreshToken');
+
+    console.log('[DEBUG] Home.jsx - accessToken:', accessToken);
+    console.log('[DEBUG] Home.jsx - refreshToken:', refreshToken);
+
+    if (!accessToken) {
+      console.warn(
+        '[WARNING] accessToken이 없습니다. 로그인 페이지로 이동합니다.'
+      );
+      window.location.href = '/login';
+    }
+  }, []);
 
   const handleRecordClick = () => {
     navigate('/record');
@@ -71,7 +86,7 @@ const Home = () => {
     <Wrapper>
       <Container>
         <StatusBar />
-{/* InfoPopup의 overlay */}
+        {/* InfoPopup의 overlay */}
         {(showInfoPopup || popup1Visible) && (
           <div className="overlay" onClick={handleCloseInfoPopup}></div>
         )}

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -17,6 +17,7 @@ import DummyBook1 from '../../assets/dummyBook1.svg';
 import DummyBook2 from '../../assets/dummyBook2.svg';
 import InfoPopup from '../../components/infoPopup/InfoPopup';
 //import DummyBook3 from '../../assets/dummyBook3.svg';
+import apiClient from '../../apis/instance/apiClient';
 const Home = () => {
   const navigate = useNavigate(); // useNavigate 훅 사용
   //const [bookCount, setBookCount] = useState(0); // 백엔드에서 가져올 값
@@ -27,6 +28,7 @@ const Home = () => {
   const [popup1Visible, setPopup1Visible] = useState(false); // #popup1 상태
 
   useEffect(() => {
+    console.log('[DEBUG] Home.jsx - 페이지 로드됨, API 요청 실행');
     const accessToken = localStorage.getItem('accessToken');
     const refreshToken = localStorage.getItem('refreshToken');
 
@@ -39,6 +41,16 @@ const Home = () => {
       );
       window.location.href = '/login';
     }
+    //주석시작
+    apiClient
+      .get('/user/profile') // 🔥 API 요청 실행
+      .then((response) => {
+        console.log('[DEBUG] 사용자 정보 가져오기 성공:', response.data);
+      })
+      .catch((error) => {
+        console.error('[ERROR] 사용자 정보 가져오기 실패:', error);
+      });
+    //주석끝
   }, []);
 
   const handleRecordClick = () => {

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -1,28 +1,96 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { LoginContainer, ButtonContainer } from './Login.styles';
 import UserInputField from '../../components/userInputField/UserInputField';
 import StatusBar from '../../components/statusbar/StatusBar';
 import BlueBtn from '../../components/blueBtn/BlueBtn';
 import Title from '../../assets/title.svg';
+import { login } from '../../apis/authApi'; // 로그인 API 함수 가져오기
+import { setAccessToken } from '../../apis/instance/apiClient'; // accessToken 업데이트 함수 가져오기
 const Login = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleLogin = async () => {
+    try {
+      if (!email) {
+        setErrorMessage('이메일을 입력해주세요.');
+        return;
+      }
+      if (!password) {
+        setErrorMessage('비밀번호를 입력해주세요.');
+        return;
+      }
+      console.log('[DEBUG] 로그인 요청 전송:', { email, password });
+
+      const response = await login(email, password);
+      console.log('[DEBUG] 로그인 함수가 반환한 값:', response);
+
+      if (!response || !response.data) {
+        throw new Error('서버 응답이 없습니다.');
+      }
+
+      const responseData = response.data; // response.data 객체 추출
+      console.log('[DEBUG] responseData:', responseData);
+
+      const { accessToken, refreshToken, userId } = responseData;
+
+      if (!accessToken || !refreshToken || !userId) {
+        throw new Error('서버 응답에서 필요한 데이터가 없습니다.');
+      }
+
+      // 로그인 성공 후 accessToken 업데이트
+      setAccessToken(accessToken);
+      console.log('[DEBUG] accessToken 저장 완료:', accessToken);
+
+      // 로그인 성공 후 페이지 이동 (예: 메인 페이지)
+      window.location.href = '/home';
+    } catch (error) {
+      console.error('[ERROR] 로그인 실패:', error);
+      if (error.response) {
+        console.error(
+          '[ERROR] 서버 응답 메시지:',
+          error.response.data?.message || '알 수 없는 오류'
+        );
+        setErrorMessage(
+          error.response.data?.message || '로그인 중 오류가 발생했습니다.'
+        );
+      } else {
+        console.error('[ERROR] 네트워크 또는 기타 오류:', error.message);
+        setErrorMessage('로그인 중 오류가 발생했습니다.');
+      }
+    }
+  };
+
   return (
     <LoginContainer>
       <StatusBar />
       <img className="title" src={Title} alt="제목" />
+
       <UserInputField
         className="input-field"
         placeholder="이메일 입력"
         labelText="이메일"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
       />
+
       <UserInputField
         className="input-field"
         placeholder="비밀번호 입력"
         labelText="비밀번호"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
       />
+
+      {errorMessage && <p style={{ color: 'red' }}>{errorMessage}</p>}
+
       {/* 버튼 컨테이너 */}
       <ButtonContainer>
-        <BlueBtn text="시작하기" />
+        <BlueBtn text="시작하기" onClick={handleLogin} />
       </ButtonContainer>
+
       <button className="find-password">비밀번호를 잊으셨나요?</button>
       <div className="question">
         계정이 없으신가요? <span className="sign-up">회원가입</span>

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { LoginContainer, ButtonContainer } from './Login.styles';
 import UserInputField from '../../components/userInputField/UserInputField';
 import StatusBar from '../../components/statusbar/StatusBar';
@@ -10,6 +11,8 @@ const Login = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+
+  const navigate = useNavigate();
 
   const handleLogin = async () => {
     try {
@@ -93,7 +96,15 @@ const Login = () => {
 
       <button className="find-password">비밀번호를 잊으셨나요?</button>
       <div className="question">
-        계정이 없으신가요? <span className="sign-up">회원가입</span>
+        계정이 없으신가요?{' '}
+        <span
+          className="sign-up"
+          onClick={() => {
+            navigate('/signup');
+          }}
+        >
+          회원가입
+        </span>
       </div>
       <div className="agree">
         가입시 <span>이용약관</span> 및 <span>개인정보 처리방침</span>에

--- a/src/pages/profile/Profile.jsx
+++ b/src/pages/profile/Profile.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Container } from './Profile.styles';
 import StatusBar from '../../components/statusbar/StatusBar';
@@ -7,17 +7,46 @@ import Title from '../../assets/title.svg';
 import ProfileImg from './profileImg.svg';
 import Plus from './plus.svg';
 import BlueBtn from '../../components/blueBtn/BlueBtn';
+import { checkNicknameAvailability } from '../../apis/verification';
+
 const Profile = () => {
-  const navigate = useNavigate(); // useNavigate 훅 사용
+  const navigate = useNavigate();
+
+  const [nickname, setNickname] = useState('');
+  const [nicknameMessage, setNicknameMessage] = useState('');
+  const [isNicknameValid, setIsNicknameValid] = useState(false);
+  const [isButtonEnabled, setIsButtonEnabled] = useState(false);
+
+  // 닉네임 중복 확인 함수
+  const handleNicknameCheck = async () => {
+    try {
+      setNicknameMessage('닉네임 확인 중...');
+      console.log('[DEBUG] 닉네임 확인 요청:', nickname);
+
+      const isAvailable = await checkNicknameAvailability(nickname);
+      if (isAvailable) {
+        setNicknameMessage('사용 가능한 닉네임입니다.');
+        setIsNicknameValid(true);
+        setIsButtonEnabled(true); // 닉네임 사용 가능하면 버튼 활성화
+      } else {
+        setNicknameMessage('*이미 존재하는 닉네임입니다.');
+        setIsNicknameValid(false);
+        setIsButtonEnabled(false);
+      }
+    } catch (error) {
+      setNicknameMessage(error.message);
+      setIsNicknameValid(false);
+      setIsButtonEnabled(false);
+    }
+  };
+
+  const handleNextButtonClick = () => {
+    sessionStorage.setItem('nickname', nickname); // 세션에 닉네임 저장
+    navigate('/category'); // "/category"로 이동
+  };
 
   const handlerBackBtnClick = () => {
     navigate('/signup');
-  };
-
-  // 닉네임 중복 여부를 확인하는 함수
-  const validateNickname = (value) => {
-    const existingNicknames = ['testUser', 'admin', 'user123']; // 서버에서 받아온 데이터라고 가정
-    return !existingNicknames.includes(value); // 중복이면 false 반환
   };
 
   return (
@@ -36,19 +65,33 @@ const Profile = () => {
       <ValidTestInput
         labelText="닉네임"
         placeholder="닉네임 설정"
-        validateInput={validateNickname}
+        value={nickname}
+        onChange={(e) => setNickname(e.target.value)}
       />
-      <span
-        className="duplicate-check"
-        onClick={() => console.log('중복확인 클릭!')}
-      >
+      {/* 닉네임 중복 확인 버튼 */}
+      <span className="duplicate-check" onClick={handleNicknameCheck}>
         중복확인
       </span>
+      {/* 닉네임 중복 확인 결과 메시지 */}
+      {nicknameMessage && (
+        <p
+          className="nickname-result-msg"
+          style={{ color: isNicknameValid ? 'green' : '#FD7472', margin: '0' }}
+        >
+          {nicknameMessage}
+        </p>
+      )}
       <div className="btn-container">
         <div className="back-btn" onClick={handlerBackBtnClick}>
           <p>이전</p>
         </div>
-        <BlueBtn className={'next'} text="다음" width={'167px'} />
+        <BlueBtn
+          className={'next'}
+          text="다음"
+          width={'167px'}
+          disabled={!isButtonEnabled}
+          onClick={handleNextButtonClick}
+        />
       </div>
     </Container>
   );

--- a/src/pages/profile/Profile.styles.jsx
+++ b/src/pages/profile/Profile.styles.jsx
@@ -16,6 +16,9 @@ export const Container = styled.div`
     position: absolute;
     top: 243px;
     left: 118px;
+    width: 158px;
+    height: 158px;
+    border-radius: 50%;
   }
 
   .plus-btn {

--- a/src/pages/profile/Profile.styles.jsx
+++ b/src/pages/profile/Profile.styles.jsx
@@ -88,4 +88,14 @@ export const Container = styled.div`
       font-weight: 500;
     }
   }
+
+  .nickname-result-msg {
+    position: absolute;
+    top: 495px;
+    left: 34px;
+    font-family: Pretendard;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 500;
+  }
 `;

--- a/src/pages/signup/PasswordInput.jsx
+++ b/src/pages/signup/PasswordInput.jsx
@@ -1,21 +1,33 @@
-import React from 'react'
+import React from 'react';
 import PropTypes from 'prop-types';
 import { InputWrapper, StyledInput, LabelText } from './PasswordInput.styles';
-const PasswordInput = ({ placeholder, labelText, className }) => {
+const PasswordInput = ({
+  placeholder,
+  labelText,
+  className,
+  value,
+  onChange,
+}) => {
   return (
-      <InputWrapper className={className}>
-        {/* labelText는 항상 표시됩니다 */}
-        <LabelText>{labelText}</LabelText>
-        <StyledInput placeholder={placeholder} />
-      </InputWrapper>
-    );
-  };
-  
-  PasswordInput.propTypes = {
-    placeholder: PropTypes.string.isRequired, //placeholder는 필수
-    labelText: PropTypes.string.isRequired, // labelText는 필수
-    className: PropTypes.string // 클래스명은 필수 아님
-  };
-  
-  export default PasswordInput;
-  export { InputWrapper, StyledInput, LabelText };
+    <InputWrapper className={className}>
+      <LabelText>{labelText}</LabelText>
+      <StyledInput
+        type="password"
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+      />
+    </InputWrapper>
+  );
+};
+
+PasswordInput.propTypes = {
+  placeholder: PropTypes.string.isRequired, //placeholder는 필수
+  labelText: PropTypes.string.isRequired, // labelText는 필수
+  className: PropTypes.string, // 클래스명은 필수 아님
+  value: PropTypes.string.isRequired, // value는 필수
+  onChange: PropTypes.func.isRequired, // onChange는 필수 (입력 변경 감지를 위해)
+};
+
+export default PasswordInput;
+export { InputWrapper, StyledInput, LabelText };

--- a/src/pages/signup/Signup.jsx
+++ b/src/pages/signup/Signup.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { SignupContainer } from './Signup.styles';
 import StatusBar from '../../components/statusbar/StatusBar';
 import UserInputField from '../../components/userInputField/UserInputField';
@@ -7,35 +8,133 @@ import PasswordInput from './PasswordInput';
 import EyeIcon from '../../assets/eye.svg';
 import EyeOff from '../../assets/eyeoff.svg';
 import BlueBtn from '../../components/blueBtn/BlueBtn';
+import {
+  requestEmailVerification,
+  verifyEmailCode,
+} from '../../apis/verification';
+
 const Signup = () => {
+  const navigate = useNavigate();
+
+  const [email, setEmail] = useState('');
+  const [verificationCode, setVerificationCode] = useState(''); // 인증번호 입력 값
+  const [verificationMessage, setVerificationMessage] = useState('');
+  {
+    /*아래 추가 */
+  }
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordMatch, setPasswordMatch] = useState(true);
+  const [isVerified, setIsVerified] = useState(false); // 인증 완료 상태
+  const [isButtonEnabled, setIsButtonEnabled] = useState(false); // 버튼 활성화 상태
+
+  const handleBtnClick = () => {
+    sessionStorage.setItem('email', email); // ✅ 세션에 이메일 저장
+    sessionStorage.setItem('password', password); // ✅ 세션에 비밀번호 저장
+    navigate('/profile');
+  };
+
+  const handleEmailVerification = async () => {
+    try {
+      setVerificationMessage('인증 요청 중...');
+      await requestEmailVerification(email);
+      setVerificationMessage('인증 코드가 전송되었습니다.');
+    } catch (error) {
+      setVerificationMessage(error.message);
+    }
+  };
+
+  // 인증번호 검증 함수
+  const handleCodeVerification = async () => {
+    try {
+      setVerificationMessage('인증번호 확인 중...');
+      const isVerified = await verifyEmailCode(email, verificationCode);
+      if (isVerified) {
+        setVerificationMessage('인증되었습니다.');
+        setIsVerified(true);
+      } else {
+        setVerificationMessage('인증 실패. 다시 시도하세요.');
+      }
+    } catch (error) {
+      setVerificationMessage(error.message);
+    }
+  };
+
+  // 비밀번호 입력 핸들러
+  const handlePasswordChange = (e) => {
+    setPassword(e.target.value);
+    checkPasswordMatch(e.target.value, confirmPassword);
+  };
+
+  // 비밀번호 확인 입력 핸들러
+  const handleConfirmPasswordChange = (e) => {
+    setConfirmPassword(e.target.value);
+    checkPasswordMatch(password, e.target.value);
+  };
+
+  // 비밀번호 일치 여부 확인
+  const checkPasswordMatch = (pwd, confirmPwd) => {
+    const match = pwd === confirmPwd && pwd.length > 0;
+    setPasswordMatch(match);
+    setIsButtonEnabled(isVerified && match); // 인증 성공 + 비밀번호 일치 시 버튼 활성화
+  };
+
   return (
     <SignupContainer>
       <StatusBar />
       <img className="title" src={Title} alt="타이틀" />
-      <UserInputField labelText="이메일" placeholder="이메일 입력" />
-      <UserInputField labelText="" placeholder="인증코드 입력" />
-      <span
-        className="email-check"
-        onClick={() => console.log('인증하기 클릭!')}
-      >
+      <UserInputField
+        labelText="이메일"
+        placeholder="이메일 입력"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <UserInputField
+        labelText=""
+        placeholder="인증코드 입력"
+        value={verificationCode}
+        onChange={(e) => setVerificationCode(e.target.value)}
+      />
+
+      <span className="email-check" onClick={handleEmailVerification}>
         인증하기
       </span>
-      <span
-        className="duplicate-check"
-        onClick={() => console.log('인증코드 확인 클릭!')}
-      >
+
+      <span className="duplicate-check" onClick={handleCodeVerification}>
         확인
       </span>
+
+      {/* 인증 요청 결과 메시지 */}
+      {verificationMessage && (
+        <span className="verfication-result-message">
+          {verificationMessage}
+        </span>
+      )}
+
+      {/* 비밀번호 입력 */}
       <PasswordInput
         labelText="비밀번호"
         placeholder="비밀번호 입력"
         className="password-input"
+        value={password}
+        onChange={handlePasswordChange}
       />
+      {/* 비밀번호 확인 입력 */}
       <PasswordInput
         labelText=""
         placeholder="비밀번호 확인"
         className="password-check"
+        value={confirmPassword}
+        onChange={handleConfirmPasswordChange}
       />
+
+      {/* 비밀번호 불일치 메시지 */}
+      {!passwordMatch && (
+        <p style={{ color: 'red', margin: '0' }}>
+          비밀번호가 일치하지 않습니다.
+        </p>
+      )}
+
       <img
         className="eye-input"
         src={EyeIcon}
@@ -48,8 +147,13 @@ const Signup = () => {
         alt="누르면 보이게"
         onClick={() => console.log('Image2 clicked!')}
       />
-
-      <BlueBtn text="다음" className="start-btn" disabled={true} />
+      {/* 회원가입 버튼 (활성화 조건: 인증 완료 + 비밀번호 일치) */}
+      <BlueBtn
+        text="다음"
+        className="start-btn"
+        disabled={!isButtonEnabled}
+        onClick={handleBtnClick}
+      />
     </SignupContainer>
   );
 };

--- a/src/pages/signup/Signup.jsx
+++ b/src/pages/signup/Signup.jsx
@@ -130,9 +130,7 @@ const Signup = () => {
 
       {/* 비밀번호 불일치 메시지 */}
       {!passwordMatch && (
-        <p style={{ color: 'red', margin: '0' }}>
-          비밀번호가 일치하지 않습니다.
-        </p>
+        <p className="pwd-result-msg">비밀번호가 일치하지 않습니다.</p>
       )}
 
       <img

--- a/src/pages/signup/Signup.jsx
+++ b/src/pages/signup/Signup.jsx
@@ -15,6 +15,12 @@ const Signup = () => {
       <UserInputField labelText="이메일" placeholder="이메일 입력" />
       <UserInputField labelText="" placeholder="인증코드 입력" />
       <span
+        className="email-check"
+        onClick={() => console.log('인증하기 클릭!')}
+      >
+        인증하기
+      </span>
+      <span
         className="duplicate-check"
         onClick={() => console.log('인증코드 확인 클릭!')}
       >

--- a/src/pages/signup/Signup.styles.jsx
+++ b/src/pages/signup/Signup.styles.jsx
@@ -59,6 +59,14 @@ export const SignupContainer = styled.div`
     margin: 0;
   }
 
+  .pwd-result-msg {
+    position: absolute;
+    top: 530px;
+    right: 40px;
+    color: red;
+    margin: 0;
+  }
+
   .password-input {
     position: absolute;
     margin-top: 60.24px;

--- a/src/pages/signup/Signup.styles.jsx
+++ b/src/pages/signup/Signup.styles.jsx
@@ -51,6 +51,14 @@ export const SignupContainer = styled.div`
     left: 295px;
   }
 
+  .verfication-result-message {
+    position: absolute;
+    top: 356px;
+    right: 40px;
+    color: red;
+    margin: 0;
+  }
+
   .password-input {
     position: absolute;
     margin-top: 60.24px;

--- a/src/pages/signup/Signup.styles.jsx
+++ b/src/pages/signup/Signup.styles.jsx
@@ -24,11 +24,8 @@ export const SignupContainer = styled.div`
     font-weight: 500;
   }
 
-  .duplicate-check {
-    position: absolute;
-    z-index: 100;
-    top: 320px;
-    left: 307px;
+  .duplicate-check,
+  .email-check {
     color: #a3a3a3;
     font-family: Pretendard;
     font-size: 11px;
@@ -38,6 +35,20 @@ export const SignupContainer = styled.div`
     letter-spacing: 0.5px;
     cursor: pointer;
     align-self: flex-end; /* 오른쪽 끝에 위치하게 설정 */
+  }
+
+  .duplicate-check {
+    position: absolute;
+    z-index: 100;
+    top: 319px;
+    left: 307px;
+  }
+
+  .email-check {
+    position: absolute;
+    z-index: 100;
+    top: 259px;
+    left: 295px;
   }
 
   .password-input {

--- a/src/pages/signup/ValidTestInput.jsx
+++ b/src/pages/signup/ValidTestInput.jsx
@@ -1,27 +1,17 @@
 // ValidTestInput.jsx
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { InputWrapper, StyledInput, LabelText, AlertText } from './ValidTestInput.styles';
+import { InputWrapper, StyledInput, LabelText } from './ValidTestInput.styles';
 
-const ValidTestInput = ({ placeholder, labelText, validateInput }) => {
-  const [inputValue, setInputValue] = useState('');
-  const [isValid, setIsValid] = useState(true); // true: valid or not checked, false: invalid
-
-  const handleChange = (e) => {
-    const value = e.target.value;
-    setInputValue(value);
-    setIsValid(validateInput(value));
-  };
-
+const ValidTestInput = ({ placeholder, labelText, value, onChange }) => {
   return (
     <InputWrapper>
       <LabelText>{labelText}</LabelText>
-      <StyledInput 
-        placeholder={placeholder} 
-        value={inputValue} 
-        onChange={handleChange} 
+      <StyledInput
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
       />
-      {!isValid && <AlertText>이미 존재하는 아이디입니다.</AlertText>}
     </InputWrapper>
   );
 };
@@ -29,7 +19,9 @@ const ValidTestInput = ({ placeholder, labelText, validateInput }) => {
 ValidTestInput.propTypes = {
   placeholder: PropTypes.string.isRequired,
   labelText: PropTypes.string.isRequired,
-  validateInput: PropTypes.func.isRequired, // Function to validate the input
+  value: PropTypes.string.isRequired, // 입력값을 부모에서 관리
+  onChange: PropTypes.func.isRequired, // 입력 핸들러 (부모에서 제어)
+  //  errorMessage: PropTypes.string, // 오류 메시지 (닉네임 중복 시 표시)
 };
 
 export default ValidTestInput;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

>이메일 인증요청, 인증확인, 닉네임 중복확인 이렇게 3가지 api 연동을 완료 하였습니다. 그 외 api 연동후 테스트하다가 발견한 
몇 가지 css 를 보완하였습니다.

## 📸 스크린샷

> 설명을 위해 스크린샷이 필요하다면 첨부해주세요
![image](https://github.com/user-attachments/assets/2cd17d2f-7756-4fc8-b80d-78697fee179d)


## 💬 리뷰 요구사항

각각 연동된 api 동작 이후 회원가입 과정 중에 필요한 정보들을 세션에 담아 저장했습니다. 저장해둔 값들은 추후 회원가입 완료 직전 과정에서 회원가입 api명세서에 명시된 엔트리들을  한번에 서버로 보낼 예정입니다.
