### PR TITLE
[Fix] 2월 17일 QA 수정사항 반영 완료

### DIFF
--- a/src/apis/mypageReadingCalendarAPI.js
+++ b/src/apis/mypageReadingCalendarAPI.js
@@ -17,10 +17,21 @@ export const mypageReadingCalendarAPI = {
       );
 
       if (response.data.code === 200 && response.data.data.calendarList) {
+        // const transformedData = response.data.data.calendarList.reduce(
+        //   (acc, item) => {
+        //     const day = parseInt(item.date.split('.')[2]);
+        //     acc[day] = item.imageUrl;
+        //     return acc;
+        //   },
+        //   {}
+        // );
         const transformedData = response.data.data.calendarList.reduce(
           (acc, item) => {
             const day = parseInt(item.date.split('.')[2]);
-            acc[day] = item.imageUrl;
+            if (!acc[day]) {
+              acc[day] = [];
+            }
+            acc[day].push(item.imageUrl);
             return acc;
           },
           {}

--- a/src/components/popup/DateSelectorPopup.jsx/DateSelectorPopup.jsx
+++ b/src/components/popup/DateSelectorPopup.jsx/DateSelectorPopup.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useMemo } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 
 const Overlay = styled.div`
@@ -148,16 +148,16 @@ const DateSelectorPopup = ({ onClose, onSelect, currentDate, signupDate }) => {
   ];
 
   // 선택된 연도가 가입 연도와 같을 경우, 가입월 이후의 월만 표시
-  const months = useMemo(() => {
-    if (selected.year === signupYear) {
-      const signupMonthNum = parseInt(signupMonth);
-      return allMonths.filter((month, index) => {
-        if (index === 0) return true; // '전체보기' 항상 포함
-        return index === 0 || parseInt(month) >= signupMonthNum;
-      });
-    }
-    return allMonths;
-  }, [selected.year, signupYear, signupMonth]);
+  // const months = useMemo(() => {
+  //   if (selected.year === signupYear) {
+  //     const signupMonthNum = parseInt(signupMonth);
+  //     return allMonths.filter((month, index) => {
+  //       if (index === 0) return true; // '전체보기' 항상 포함
+  //       return index === 0 || parseInt(month) >= signupMonthNum;
+  //     });
+  //   }
+  //   return allMonths;
+  // }, [selected.year, signupYear, signupMonth]);
 
   const handleScroll = (ref, items, type) => {
     if (!ref.current) return;
@@ -178,7 +178,7 @@ const DateSelectorPopup = ({ onClose, onSelect, currentDate, signupDate }) => {
   useEffect(() => {
     // 초기 스크롤 위치 설정
     const yearIndex = years.indexOf(selected.year);
-    const monthIndex = months.indexOf(selected.month);
+    const monthIndex = allMonths.indexOf(selected.month);
 
     if (yearRef.current && yearIndex !== -1) {
       yearRef.current.scrollTop = yearIndex * 40;
@@ -220,9 +220,9 @@ const DateSelectorPopup = ({ onClose, onSelect, currentDate, signupDate }) => {
           </PickerColumn>
           <PickerColumn
             ref={monthRef}
-            onScroll={() => handleScroll(monthRef, months, 'month')}
+            onScroll={() => handleScroll(monthRef, allMonths, 'month')}
           >
-            {months.map((month) => (
+            {allMonths.map((month) => (
               <PickerItem key={month} $selected={selected.month === month}>
                 {month}
               </PickerItem>

--- a/src/components/readingLog/Item.styles.jsx
+++ b/src/components/readingLog/Item.styles.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 export const Container = styled.div`
   display: flex;
@@ -117,5 +118,14 @@ export const MetaItem = styled.div`
     font-style: normal;
     font-weight: 600;
     line-height: 23.505px; /* 200% */
+  }
+`;
+
+export const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
+
+  &:hover {
+    text-decoration: none;
   }
 `;

--- a/src/components/readingLog/Item.styles.jsx
+++ b/src/components/readingLog/Item.styles.jsx
@@ -87,7 +87,7 @@ export const Tag = styled.span`
   justify-content: center;
   align-items: center;
   border-radius: 100px;
-  background: #6aa5f8;
+  background: ${({ $status }) => ($status === '혼자' ? '#A3C7FA' : '#6AA5F8')};
   color: #fff;
   font-variant-numeric: lining-nums proportional-nums;
   font-feature-settings: 'dlig' on;

--- a/src/components/readingLog/RoomListNotRead.jsx
+++ b/src/components/readingLog/RoomListNotRead.jsx
@@ -26,7 +26,7 @@ const RoomListNotRead = ({ rooms }) => {
         <Item key={room.id}>
           <img src={room.coverImage} className="book-cover" />
           <BookInfo>
-            <Tag>{room.people}</Tag>
+            <Tag $status={room.people}>{room.people}</Tag>
             <p className="roomAuthor">{room.author}</p>
             <div className="BookContainer">
               <span className="BookTitle">{room.book}</span>

--- a/src/components/readingLog/RoomListNotRead.jsx
+++ b/src/components/readingLog/RoomListNotRead.jsx
@@ -1,5 +1,12 @@
 import React, { useState } from 'react';
-import { Container, Item, BookInfo, Tag, MetaItem } from './Item.styles';
+import {
+  Container,
+  Item,
+  BookInfo,
+  Tag,
+  MetaItem,
+  StyledLink,
+} from './Item.styles';
 import BookInfoPopup from './BookInfoPopup';
 import clockIcon from '../../assets/clock3.svg';
 import progressIcon from '../../assets/note3.svg';
@@ -23,26 +30,31 @@ const RoomListNotRead = ({ rooms }) => {
   return (
     <Container>
       {rooms.map((room) => (
-        <Item key={room.id}>
-          <img src={room.coverImage} className="book-cover" />
-          <BookInfo>
-            <Tag $status={room.people}>{room.people}</Tag>
-            <p className="roomAuthor">{room.author}</p>
-            <div className="BookContainer">
-              <span className="BookTitle">{room.book}</span>
-            </div>
-            <div className="roomMeta">
-              <MetaItem>
-                <img src={clockIcon} alt="recentEdited" className="icon" />
-                <span className="data">{room.recentEdit}</span>
-              </MetaItem>
-              <MetaItem>
-                <img src={progressIcon} alt="progress" className="icon" />
-                <span className="data">{Math.floor(room.progress)}%</span>
-              </MetaItem>
-            </div>
-          </BookInfo>
-        </Item>
+        <StyledLink
+          key={room.id} // key를 여기로 이동
+          to={`/rooms/${room.id}/info`}
+        >
+          <Item key={room.id}>
+            <img src={room.coverImage} className="book-cover" />
+            <BookInfo>
+              <Tag $status={room.people}>{room.people}</Tag>
+              <p className="roomAuthor">{room.author}</p>
+              <div className="BookContainer">
+                <span className="BookTitle">{room.book}</span>
+              </div>
+              <div className="roomMeta">
+                <MetaItem>
+                  <img src={clockIcon} alt="recentEdited" className="icon" />
+                  <span className="data">{room.recentEdit}</span>
+                </MetaItem>
+                <MetaItem>
+                  <img src={progressIcon} alt="progress" className="icon" />
+                  <span className="data">{Math.floor(room.progress)}%</span>
+                </MetaItem>
+              </div>
+            </BookInfo>
+          </Item>
+        </StyledLink>
       ))}
       {selectedRoom && (
         <BookInfoPopup

--- a/src/components/readingLog/RoomListRead.jsx
+++ b/src/components/readingLog/RoomListRead.jsx
@@ -9,7 +9,7 @@ const RoomListRead = ({ rooms }) => {
           <img src={room.coverImage} alt={room.title} className="book-cover" />
 
           <BookInfo>
-            <Tag>{room.people}</Tag>
+            <Tag $status={room.people}>{room.people}</Tag>
             <p className="roomAuthor">{room.author}</p>
             <div className="BookContainer">
               <span className="BookTitle">{room.book}</span>

--- a/src/components/readingLog/RoomListRead.jsx
+++ b/src/components/readingLog/RoomListRead.jsx
@@ -1,26 +1,42 @@
 import React from 'react';
-import { Container, Item, BookInfo, Tag, MetaItem } from './Item.styles';
+import {
+  Container,
+  Item,
+  BookInfo,
+  Tag,
+  MetaItem,
+  StyledLink,
+} from './Item.styles';
 
 const RoomListRead = ({ rooms }) => {
   return (
     <Container>
       {rooms.map((room) => (
-        <Item key={room.id}>
-          <img src={room.coverImage} alt={room.title} className="book-cover" />
+        <StyledLink
+          key={room.id} // key를 여기로 이동
+          to={`/rooms/${room.id}/info`}
+        >
+          <Item key={room.id}>
+            <img
+              src={room.coverImage}
+              alt={room.title}
+              className="book-cover"
+            />
 
-          <BookInfo>
-            <Tag $status={room.people}>{room.people}</Tag>
-            <p className="roomAuthor">{room.author}</p>
-            <div className="BookContainer">
-              <span className="BookTitle">{room.book}</span>
-            </div>
-            <div className="roomMeta">
-              <MetaItem>
-                <span className="data">{room.date}</span>
-              </MetaItem>
-            </div>
-          </BookInfo>
-        </Item>
+            <BookInfo>
+              <Tag $status={room.people}>{room.people}</Tag>
+              <p className="roomAuthor">{room.author}</p>
+              <div className="BookContainer">
+                <span className="BookTitle">{room.book}</span>
+              </div>
+              <div className="roomMeta">
+                <MetaItem>
+                  <span className="data">{room.date}</span>
+                </MetaItem>
+              </div>
+            </BookInfo>
+          </Item>
+        </StyledLink>
       ))}
     </Container>
   );

--- a/src/pages/mypage/readingcalendar/CalendarBookInfoPopup.jsx
+++ b/src/pages/mypage/readingcalendar/CalendarBookInfoPopup.jsx
@@ -83,7 +83,7 @@ const TitleText = styled.span`
 `;
 
 const ReadingStatus = styled.span`
-  /* color: ${({ $status }) => ($status === '혼자' ? '#A3C7FA' : '#6AA5F8')}; */
+  background: ${({ $status }) => ($status === '혼자' ? '#A3C7FA' : '#6AA5F8')};
 
   display: inline-flex;
   width: 40px;
@@ -95,7 +95,6 @@ const ReadingStatus = styled.span`
   justify-content: center;
   align-items: center;
   border-radius: 100px;
-  background: #6aa5f8;
   color: #fff;
   font-variant-numeric: lining-nums proportional-nums;
   font-feature-settings: 'dlig' on;

--- a/src/pages/mypage/readingcalendar/CalendarContent.jsx
+++ b/src/pages/mypage/readingcalendar/CalendarContent.jsx
@@ -38,10 +38,35 @@ const DateNumber = styled.span`
   line-height: 140%;
 `;
 
-const BookImage = styled.img`
+const BookImagesContainer = styled.div`
+  position: relative;
   width: 45.35px;
   height: 66.52px;
   object-fit: cover;
+`;
+
+const StyledBookImage = styled.img`
+  position: absolute;
+  left: 0;
+  width: 45.35px;
+  height: 66.52px;
+  object-fit: cover;
+  transition: all 0.3s ease;
+
+  &:nth-child(3) {
+    bottom: 17.24px;
+    z-index: 1;
+  }
+
+  &:nth-child(2) {
+    bottom: 8.62px;
+    z-index: 2;
+  }
+
+  &:nth-child(1) {
+    bottom: 0;
+    z-index: 3;
+  }
 `;
 
 const float = keyframes`
@@ -157,9 +182,24 @@ const CalendarContent = ({ selectedDate }) => {
           onClick={() => date && handleDateClick(date)}
         >
           {date && (
+            // <>
+            //   {calendarData[date] ? (
+            //     <BookImage src={calendarData[date]} alt={`Book on ${date}`} />
+            //   ) : (
+            //     <DateNumber>{date}</DateNumber>
+            //   )}
+            // </>
             <>
-              {calendarData[date] ? (
-                <BookImage src={calendarData[date]} alt={`Book on ${date}`} />
+              {calendarData[date]?.length > 0 ? (
+                <BookImagesContainer>
+                  {calendarData[date].slice(0, 3).map((imageUrl, imgIndex) => (
+                    <StyledBookImage
+                      key={imgIndex}
+                      src={imageUrl}
+                      alt={`Book ${imgIndex + 1} on ${date}`}
+                    />
+                  ))}
+                </BookImagesContainer>
               ) : (
                 <DateNumber>{date}</DateNumber>
               )}

--- a/src/pages/mypage/readingcalendar/CalendarHandler.jsx
+++ b/src/pages/mypage/readingcalendar/CalendarHandler.jsx
@@ -8,7 +8,7 @@ const HeaderContainer = styled.div`
   justify-content: center;
   align-items: center;
   padding: 20px 0;
-  width: 220px;
+  min-width: 220px;
   height: 44px;
   flex-shrink: 0;
 `;

--- a/src/pages/readingLog/ReadingLog.jsx
+++ b/src/pages/readingLog/ReadingLog.jsx
@@ -82,7 +82,7 @@ const ReadingLog = () => {
 
   if (isLoading) return <LoadingPage />;
 
-  console.log(signupDate);
+  // console.log(signupDate);
   return (
     <Container>
       <HeaderContainer>
@@ -100,7 +100,7 @@ const ReadingLog = () => {
           $active={!isRead}
           onClick={() => handleFilterChange(false)}
         >
-          다 안읽었어요
+          다 안 읽었어요
         </FilterRightButton>
       </FilterButtons>
 

--- a/src/pages/readingLog/ReadingLog.styles.jsx
+++ b/src/pages/readingLog/ReadingLog.styles.jsx
@@ -142,8 +142,8 @@ export const DateSelector = styled.div`
 export const NoItems = styled.div`
   justify-content: center;
   align-items: center;
-  margin-left: 147px;
-  margin-top: 275px;
+  margin-left: 144px;
+  margin-top: 190px;
   color: #666;
   font-family: Pretendard;
   font-size: 14px;

--- a/src/pages/search/DatePicker.jsx
+++ b/src/pages/search/DatePicker.jsx
@@ -3,6 +3,14 @@ import styled from 'styled-components';
 
 const DatePickerContainer = styled.div`
   margin: 16px 0;
+  /* position: absolute; */
+`;
+
+const DatePickerHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
 `;
 
 const DatePickerLabel = styled.div`
@@ -12,7 +20,27 @@ const DatePickerLabel = styled.div`
   font-style: normal;
   font-weight: 500;
   line-height: 140%; /* 19.6px */
-  margin-bottom: 8px;
+`;
+
+const DatePickerReset = styled.button`
+  display: inline-flex;
+  padding: 4px 12px;
+  height: 21px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 100px;
+  background-color: #6aa5f8;
+  color: #fff;
+  margin-top: 8px;
+  margin-right: 8px;
+  font-family: Pretendard;
+  font-size: 9.624px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 139.895%;
+  letter-spacing: 0.096px;
+  border: none;
+  cursor: pointer;
 `;
 
 const DateInputsContainer = styled.div`
@@ -24,6 +52,7 @@ const DateInputsContainer = styled.div`
 const DateInput = styled.div`
   padding: 12px 16px;
   border-radius: 12px;
+  font-size: 13px;
   text-align: center;
   cursor: pointer;
   color: ${(props) => (props.$isSelected ? '#FFF' : '#000')};
@@ -112,7 +141,7 @@ const DatePicker = ({
   const [currentDate, setCurrentDate] = useState(new Date());
 
   const formatDate = (date) => {
-    if (!date) return 'yyyy.mm.dd';
+    if (!date) return 'YYYY.MM.DD';
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');
@@ -155,6 +184,7 @@ const DatePicker = ({
 
   const handleStartDateClick = (date) => {
     if (onStartDateChange) {
+      console.log('startdate' + date); // Thu May 15 2025 00:00:00 GMT+0900 (한국 표준시)
       onStartDateChange(date);
     }
     setShowStartCalendar(false);
@@ -162,6 +192,7 @@ const DatePicker = ({
 
   const handleEndDateClick = (date) => {
     if (onEndDateChange) {
+      console.log('enddate' + date); // Wed Jun 11 2025 00:00:00 GMT+0900 (한국 표준시)
       onEndDateChange(date);
     }
     setShowEndCalendar(false);
@@ -174,14 +205,22 @@ const DatePicker = ({
 
   const isDateDisabled = (date) => {
     if (!date) return true;
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    return date < today;
+    // const today = new Date();
+    // today.setHours(0, 0, 0, 0);
+    // return date < today;
+  };
+
+  const handleReset = () => {
+    if (onStartDateChange) onStartDateChange(null);
+    if (onEndDateChange) onEndDateChange(null);
   };
 
   return (
     <DatePickerContainer>
-      <DatePickerLabel>{label}</DatePickerLabel>
+      <DatePickerHeader>
+        <DatePickerLabel>{label}</DatePickerLabel>
+        <DatePickerReset onClick={handleReset}>reset</DatePickerReset>
+      </DatePickerHeader>
       <DateInputsContainer>
         <DateInput
           $date-has-value={startDate}
@@ -225,7 +264,7 @@ const DatePicker = ({
               <DateCell
                 key={index}
                 $isSelected={isDateSelected(date, startDate)}
-                disabled={isDateDisabled(date)}
+                // disabled={isDateDisabled(date)}
                 onClick={() => date && handleStartDateClick(date)}
               >
                 {date ? date.getDate() : ''}

--- a/src/pages/search/FilterPopup.jsx
+++ b/src/pages/search/FilterPopup.jsx
@@ -62,19 +62,19 @@ const FilterPopup = ({ onClose, onApply, $currentFilters }) => {
     $currentFilters.category || ''
   );
   const [deadlineStartDate, setDeadlineStartDate] = useState(
-    $currentFilters.deadline?.start || null
+    $currentFilters?.deadline?.start || null
   );
   const [deadlineEndDate, setDeadlineEndDate] = useState(
-    $currentFilters.deadline?.end || null
+    $currentFilters?.deadline?.end || null
   );
   const [periodStartDate, setPeriodStartDate] = useState(
-    $currentFilters.period?.start || null
+    $currentFilters?.period?.start || null
   );
   const [periodEndDate, setPeriodEndDate] = useState(
-    $currentFilters.period?.end || null
+    $currentFilters?.period?.end || null
   );
   const [recordCount, setRecordCount] = useState(
-    $currentFilters.recordcnt || 0
+    $currentFilters?.recordcnt || 0
   );
 
   const categories = [
@@ -103,6 +103,18 @@ const FilterPopup = ({ onClose, onApply, $currentFilters }) => {
   };
 
   const handleApply = () => {
+    console.log({
+      category: selectedCategory,
+      deadline: {
+        start: deadlineStartDate,
+        end: deadlineEndDate,
+      },
+      period: {
+        start: periodStartDate,
+        end: periodEndDate,
+      },
+      recordcnt: recordCount,
+    });
     onApply({
       category: selectedCategory,
       deadline: {

--- a/src/pages/search/SearchBar.jsx
+++ b/src/pages/search/SearchBar.jsx
@@ -127,7 +127,7 @@ export const SearchBar = ({
             </DeleteIconWrapper>
           )}
           <SearchIconWrapper>
-            <img src={searchIcon} alt="search" onClick={onSearch} />
+            <img src={searchIcon} alt="search" onClick={() => onSearch()} />
           </SearchIconWrapper>
         </IconContainer>
       </SearchInput>

--- a/src/pages/search/SearchBar.jsx
+++ b/src/pages/search/SearchBar.jsx
@@ -119,6 +119,7 @@ export const SearchBar = ({
           value={value}
           onChange={onChange}
           onKeyDown={handleKeyPress}
+          maxLength={15}
         />
         <IconContainer>
           {value && (

--- a/src/pages/search/search.jsx
+++ b/src/pages/search/search.jsx
@@ -75,8 +75,9 @@ export default function Search() {
   };
 
   // searchBar 돋보기 Button
-  const handleSearch = async (directQuery, newListType) => {
+  const handleSearch = async (directQuery, newSearchType, newListType) => {
     const queryToUse = directQuery || searchQuery;
+    const searchtypeToUse = newSearchType || searchType;
     const typeToUse = newListType || listType;
 
     if (!queryToUse.trim()) return;
@@ -91,7 +92,7 @@ export default function Search() {
         setBookHasMore(true);
         const booksHasNext = await fetchBookSearchResults({
           searchQuery: queryToUse,
-          searchType,
+          searchType: searchtypeToUse,
           filters: appliedFilters,
           setBooks,
           page: 0,
@@ -103,7 +104,7 @@ export default function Search() {
         setRoomHasMore(true);
         const roomsHasNext = await fetchRoomSearchResults({
           searchQuery: queryToUse,
-          searchType,
+          searchType: searchtypeToUse,
           filters: appliedFilters,
           setRooms,
           page: 0,
@@ -139,6 +140,7 @@ export default function Search() {
       room: '방 이름',
     };
     setSearchType(typeLabels[typeId]);
+    handleSearch();
     setShowPopup(false);
   };
 

--- a/src/pages/search/search.styles.jsx
+++ b/src/pages/search/search.styles.jsx
@@ -78,8 +78,8 @@ export const BookList = styled.div`
 export const NoResultsMessage = styled.div`
   justify-content: center;
   align-items: center;
-  margin-left: 147px;
-  margin-top: 275px;
+  margin-left: 144px;
+  margin-top: 190px; // 459 -> 419
   color: #666;
   font-family: Pretendard;
   font-size: 14px;


### PR DESCRIPTION
## 📝 작업 내용

> 2월 17일 QA 수정사항 반영 완료

책찾기 필터 - reset 버튼, 필터 이전 날짜 선택 가능하게, 날짜선택 대문자로
**책찾기 - 무한스크롤 수정
책찾기 - 검색바 15자 제한

모든 화면 - “검색결과가 없습니다” 위치 바꾸기

책찾기 - 돋보기 안돼(확인), 최근검색어 엑스가 너무 커, 검색필터 바로 적용
독서기록장 - DateHandler width size 수정

독서기록장 다 읽었어요 / 다 안 읽었어요 탭 : '다 안 읽었어요' 텍스트 띄어쓰기 확인해주세요
독서기록장 혼자/같이 배경 색 다르게 해주세요 지금은 모든 배경색이(6AA5F8)으로 되어있어요! *같이 배경색 : 6AA5F8, 혼자 배경색 : A3C7FA
독서기록장 날짜달력 : 회원가입한 연도만 보여주기
독서기록장 날짜달력 : 스크롤로만 날짜를 선택할 수 있는걸까요? 클릭도 가능하게 해야할 것 같습니다! 예를 들어 현재 25년 2월이 되어있으면, 12월을 선택했을 때 바로 12월로 선택되도록 해야할 것 같아요 (이건 불가능)
독서기록장 - 다 안읽었어요 하단팝업 디자인 수정 -> 다 안 읽었어요 다 읽었어요 책 이름 선택하면 /rooms/:roomId/info
독서달력 - 같은날 두개이상 책이미지 45.35 66.52 (위에 8.65)

## 📸 스크린샷

> 설명을 위해 스크린샷이 필요하다면 첨부해주세요

## 💬 리뷰 요구사항

> 백엔드 요청으로 무한 스크롤 로직 수정 부분은 제가 조금 더 해보고 수정할 예정입니다~
